### PR TITLE
Fix dependabot PR #16: update @types/uuid, keep eslint on ^9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@types/prop-types": "^15.7.15",
         "@types/react": "^19",
         "@types/react-dom": "^19",
-        "@types/uuid": "^9.0.8",
+        "@types/uuid": "^11.0.0",
         "autoprefixer": "^10.4.19",
         "eslint": "^9",
         "eslint-config-next": "16.1.6",
@@ -2667,11 +2667,15 @@
       "license": "MIT"
     },
     "node_modules/@types/uuid": {
-      "version": "9.0.8",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
-      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-11.0.0.tgz",
+      "integrity": "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA==",
+      "deprecated": "This is a stub types definition. uuid provides its own type definitions, so you do not need this installed.",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "uuid": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@types/prop-types": "^15.7.15",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@types/uuid": "^9.0.8",
+    "@types/uuid": "^11.0.0",
     "autoprefixer": "^10.4.19",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",


### PR DESCRIPTION
## Summary

- Bumps `@types/uuid` from `^9.0.8` to `^11.0.0` (safe update, all tests pass)
- Keeps `eslint` pinned to `^9` — **does not** update to ESLint 10

## Why not ESLint 10?

ESLint 10 introduced a breaking change: all parsers must implement `ScopeManager#addGlobals()`. The internal Babel-based parser bundled with `eslint-config-next` 16.1.6 (used for the `next` lint config) does **not** implement this method, causing:

```
TypeError: scopeManager.addGlobals is not a function
    at addDeclaredGlobals (…/eslint/lib/languages/js/source-code/source-code.js:221:15)
```

This is a Next.js-side issue. Once `eslint-config-next` ships ESLint 10 support, we can revisit. Closes #16 by applying only the safe half of that dependency update.

## Test plan

- [x] `npm run lint` passes (ESLint 9.39.3, 0 errors)
- [x] `npm test` — all 52 tests pass
- [x] `@types/uuid` 11 is a types-only package with no runtime impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)