### PR TITLE
Add lazy-loaded daily word cache, 3-player category handicap, and E2E…

### DIFF
--- a/src/app/game/[gameId]/page.tsx
+++ b/src/app/game/[gameId]/page.tsx
@@ -15,6 +15,7 @@ type PlayerDTO = {
 
 type TurnDTO = {
   word: string | null;
+  category: string | null;
   role: 'IMPOSTOR' | 'CIVILIAN' | 'UNKNOWN';
   impostors?: string[];
   civilians?: string[];
@@ -298,7 +299,7 @@ export default function GameRoom() {
              </h2>
              
              {currentTurn ? (
-                <CurrentTurnDisplay turn={currentTurn} t={t} />
+                <CurrentTurnDisplay turn={currentTurn} t={t} playerCount={game.players.length} />
              ) : (
                  game.status === 'FINISHED' ? (
                     <div className="text-center p-4 bg-gray-100 dark:bg-slate-800 rounded">
@@ -335,16 +336,18 @@ export default function GameRoom() {
   );
 }
 
-function CurrentTurnDisplay({ turn, t }: { turn: TurnDTO, t: any }) {
+function CurrentTurnDisplay({ turn, t, playerCount }: { turn: TurnDTO, t: any, playerCount: number }) {
   const [isRevealed, setIsRevealed] = useState(false);
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
   const isImpostor = turn.role === 'IMPOSTOR';
+  // Impostors see the category as a handicap only in small games (≤3 players)
+  const showCategoryToImpostor = isImpostor && playerCount <= 3;
 
   const handleReveal = () => {
     if (isRevealed) return; // Already revealed
 
     setIsRevealed(true);
-    
+
     // Clear any existing timeout
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current);
@@ -366,7 +369,7 @@ function CurrentTurnDisplay({ turn, t }: { turn: TurnDTO, t: any }) {
   }, []);
 
   return (
-    <div 
+    <div
       data-testid="reveal-card"
       onClick={handleReveal}
       className="relative bg-slate-800 text-white p-8 rounded-xl text-center shadow-2xl max-w-lg mx-auto transform transition-all cursor-pointer overflow-hidden min-h-[300px] flex flex-col justify-center select-none dark:border dark:border-slate-700"
@@ -383,8 +386,16 @@ function CurrentTurnDisplay({ turn, t }: { turn: TurnDTO, t: any }) {
             <div data-testid="role-display" className="text-5xl font-black mb-8 tracking-wider">
               {isImpostor ? <span className="text-red-500 drop-shadow-md">IMPOSTOR</span> : <span className="text-blue-400 drop-shadow-md">CIVILIAN</span>}
             </div>
-            
+
             <div className="border-t border-slate-700 pt-8">
+              {(!isImpostor || showCategoryToImpostor) && turn.category && (
+                <div className="mb-4">
+                  <h3 className="text-xs uppercase tracking-widest text-slate-400 mb-2 font-semibold">{t("category") ?? "Category"}</h3>
+                  <div data-testid="category-display" className="text-xl font-semibold text-slate-200">
+                    {turn.category}
+                  </div>
+                </div>
+              )}
               <h3 className="text-xs uppercase tracking-widest text-slate-400 mb-4 font-semibold">{t("yourSecretWord")}</h3>
               <div data-testid="secret-word-display" className="text-4xl font-mono bg-slate-900 inline-block px-8 py-4 rounded-lg border border-slate-700 shadow-inner">
                  {isImpostor ? <span className="tracking-widest">???</span> : turn.word}

--- a/src/application/use-cases/getGameDetails.ts
+++ b/src/application/use-cases/getGameDetails.ts
@@ -16,6 +16,7 @@ export interface PlayerDTO {
 
 export interface TurnDTO {
   word: string | null;
+  category: string | null;
   role: 'IMPOSTOR' | 'CIVILIAN' | 'UNKNOWN';
   impostors?: string[];
   civilians?: string[];
@@ -88,6 +89,7 @@ export class GetGameDetailsUseCase {
 
       const dto: TurnDTO = {
         word: wordToReturn,
+        category: turn.category ?? null,
         role,
         isCurrent: isLast && !isFinished
       };

--- a/src/application/use-cases/nextTurn.ts
+++ b/src/application/use-cases/nextTurn.ts
@@ -42,10 +42,11 @@ export class NextTurnUseCase {
     const civilians = shuffled.slice(impostorCount).map(p => p.id);
     const previousWords = game.turns.map(t => t.word);
 
-    const word = await this.wordGenerator.generateWord(game.ageOfYoungestPlayer, game.language, previousWords);
+    const result = await this.wordGenerator.generateWord(game.ageOfYoungestPlayer, game.language, previousWords);
 
     const turn: Turn = {
-      word,
+      word: result.word,
+      category: result.category,
       impostors,
       civilians
     };

--- a/src/domain/entities/Game.ts
+++ b/src/domain/entities/Game.ts
@@ -9,6 +9,7 @@ export interface Player {
 
 export interface Turn {
     word: string;
+    category: string;
     impostors: string[];
     civilians: string[];
 }

--- a/src/domain/ports/WordGenerator.ts
+++ b/src/domain/ports/WordGenerator.ts
@@ -1,4 +1,9 @@
 
+export interface WordGeneratorResult {
+  category: string;
+  word: string;
+}
+
 export interface WordGenerator {
-  generateWord(age: number, language: string, previousWords: string[]): Promise<string>;
+  generateWord(age: number, language: string, previousWords: string[]): Promise<WordGeneratorResult>;
 }

--- a/src/shared/locales/de.json
+++ b/src/shared/locales/de.json
@@ -40,6 +40,7 @@
   "loadingGame": "Lade Spiel...",
   "noData": "Keine Daten",
   "yourRole": "Deine Rolle",
+  "category": "Kategorie",
   "yourSecretWord": "Dein Geheimwort",
   "findOthers": "Versuche herauszufinden, was die anderen haben!",
   "findImpostor": "Finde den Impostor!",

--- a/src/shared/locales/en.json
+++ b/src/shared/locales/en.json
@@ -40,6 +40,7 @@
   "loadingGame": "Loading game...",
   "noData": "No data",
   "yourRole": "Your Role",
+  "category": "Category",
   "yourSecretWord": "Your Secret Word",
   "findOthers": "Try to figure out what the others have!",
   "findImpostor": "Find the Impostor!",

--- a/src/shared/locales/es.json
+++ b/src/shared/locales/es.json
@@ -40,6 +40,7 @@
   "loadingGame": "Cargando juego...",
   "noData": "Sin datos",
   "yourRole": "Tu rol",
+  "category": "Categoría",
   "yourSecretWord": "Tu palabra secreta",
   "findOthers": "¡Intenta averiguar qué tienen los demás!",
   "findImpostor": "¡Encuentra al Impostor!",

--- a/src/shared/locales/fr.json
+++ b/src/shared/locales/fr.json
@@ -40,6 +40,7 @@
   "loadingGame": "Chargement du jeu...",
   "noData": "Aucune donnée",
   "yourRole": "Votre rôle",
+  "category": "Catégorie",
   "yourSecretWord": "Votre mot secret",
   "findOthers": "Essayez de deviner ce que les autres ont !",
   "findImpostor": "Trouvez l'Imposteur !",

--- a/src/shared/locales/it.json
+++ b/src/shared/locales/it.json
@@ -40,6 +40,7 @@
   "loadingGame": "Caricamento gioco...",
   "noData": "Nessun dato",
   "yourRole": "Il tuo ruolo",
+  "category": "Categoria",
   "yourSecretWord": "La tua parola segreta",
   "findOthers": "Cerca di capire cosa hanno gli altri!",
   "findImpostor": "Trova l'Impostore!",

--- a/tests/integration/getGameDetails.test.ts
+++ b/tests/integration/getGameDetails.test.ts
@@ -143,7 +143,7 @@ describe('GET /api/getGameDetails - word visibility in active turn', () => {
         { id: 'p3', name: 'Other', role: 'HOST', secret: 'secret-other' },
       ],
       turns: [
-        { word: 'Elefant', impostors: [impostorId], civilians: [civilianId, 'p3'] },
+        { word: 'Elefant', category: 'Tiere', impostors: [impostorId], civilians: [civilianId, 'p3'] },
       ],
     };
     await repo.save(game);
@@ -198,7 +198,7 @@ describe('GET /api/getGameDetails - finished game reveals everything', () => {
         { id: 'p3', name: 'Other', role: 'PLAYER', secret: 'secret-other-fin' },
       ],
       turns: [
-        { word: 'Giraffe', impostors: [impostorId], civilians: [civilianId, 'p3'] },
+        { word: 'Giraffe', category: 'Tiere', impostors: [impostorId], civilians: [civilianId, 'p3'] },
       ],
     };
     await repo.save(game);
@@ -242,8 +242,8 @@ describe('GET /api/getGameDetails - multi-turn game', () => {
         { id: 'p3', name: 'Other', role: 'PLAYER', secret: 'secret-other-multi' },
       ],
       turns: [
-        { word: 'Apfel', impostors: [impostorId], civilians: [civilianId, 'p3'] },
-        { word: 'Tiger', impostors: [impostorId], civilians: [civilianId, 'p3'] },
+        { word: 'Apfel', category: 'Obst', impostors: [impostorId], civilians: [civilianId, 'p3'] },
+        { word: 'Tiger', category: 'Tiere', impostors: [impostorId], civilians: [civilianId, 'p3'] },
       ],
     };
     await repo.save(game);


### PR DESCRIPTION
… tests

## Step 1 – Lazy-Loaded Daily Dictionary (GeminiWordGenerator)
- WordGenerator port now returns { category, word } instead of a plain string
- GeminiWordGenerator generates a batch of 10 categories × 50 words per request and caches the result in Redis under words:YYYY-MM-DD:lang (TTL 24h)
- On subsequent calls the cache is hit; previousWords are filtered locally rather than passed to Gemini, eliminating redundant API calls
- Removed 80+ hard-coded German categories; Gemini now generates language-aware categories from the prompt

## Step 2 – Game.Turn / TurnDTO carry category
- Turn entity gains a required `category` field alongside `word`
- TurnDTO in getGameDetails exposes `category: string | null`
- nextTurn use-case stores category from WordGeneratorResult into the Turn

## Step 3 – 3-Player Impostor Handicap (frontend)
- CurrentTurnDisplay receives playerCount prop
- Impostors with ≤3 players see [data-testid="category-display"] (category name) but still see "???" for the word
- Impostors with >3 players see neither category nor word
- Civilians always see both category and word
- Added "category" i18n key to all 5 locale files (de, en, es, fr, it)

## Step 4 – Playwright E2E Tests
- Extracted `revealCardFull()` helper that captures role, word, and categoryVisible within the 2-second reveal window
- Extracted `setupGameAndStartTurn(browser, n, language)` helper for reusable N-player game setup
- Test A: 3-player game – impostor sees category-display, word = "???"
- Test B: 4-player game – impostor does NOT see category-display, word = "???"
- Test C: Parameterized multilingual test for de-DE and en-US locales that verifies the full flow (create → join → start → turn) completes without error