### PR TITLE
Fix: show correct message when player is removed by host

### DIFF
--- a/src/app/game/[gameId]/page.tsx
+++ b/src/app/game/[gameId]/page.tsx
@@ -77,8 +77,13 @@ export default function GameRoom() {
           return;
         }
         
-        if (res.status === 401 || res.status === 403) {
-           setError(t("errorJoining")); 
+        if (res.status === 401) {
+           setError(t("errorJoining"));
+           return;
+        }
+
+        if (res.status === 403) {
+           setError(t("removedByHost"));
            return;
         }
         

--- a/src/shared/locales/de.json
+++ b/src/shared/locales/de.json
@@ -46,6 +46,7 @@
   "waitingForTurn": "Warte auf Rundenstart...",
   "gameOver": "Spiel vorbei. Siehe Verlauf.",
   "errorJoining": "Fehler beim Beitreten",
+  "removedByHost": "Du wurdest vom Host aus dem Spiel entfernt.",
   "gameNotFound": "Spiel nicht gefunden",
   "joining": "Beitreten...",
   "error": "Fehler",

--- a/src/shared/locales/en.json
+++ b/src/shared/locales/en.json
@@ -46,6 +46,7 @@
   "waitingForTurn": "Waiting for turn to start...",
   "gameOver": "Game over. See history.",
   "errorJoining": "Error joining",
+  "removedByHost": "You have been removed from the game by the host.",
   "gameNotFound": "Game not found",
   "joining": "Joining...",
   "error": "Error",

--- a/src/shared/locales/es.json
+++ b/src/shared/locales/es.json
@@ -46,6 +46,7 @@
   "waitingForTurn": "Esperando inicio del turno...",
   "gameOver": "Juego terminado. Ver historial.",
   "errorJoining": "Error al unirse",
+  "removedByHost": "El anfitrión te ha eliminado del juego.",
   "gameNotFound": "Juego no encontrado",
   "joining": "Uniéndose...",
   "error": "Error",

--- a/src/shared/locales/fr.json
+++ b/src/shared/locales/fr.json
@@ -46,6 +46,7 @@
   "waitingForTurn": "En attente du début du tour...",
   "gameOver": "Jeu terminé. Voir historique.",
   "errorJoining": "Erreur lors de la connexion",
+  "removedByHost": "L'hôte vous a retiré du jeu.",
   "gameNotFound": "Jeu introuvable",
   "joining": "Connexion...",
   "error": "Erreur",

--- a/src/shared/locales/it.json
+++ b/src/shared/locales/it.json
@@ -46,6 +46,7 @@
   "waitingForTurn": "In attesa dell'inizio del turno...",
   "gameOver": "Gioco finito. Vedi cronologia.",
   "errorJoining": "Errore nell'unione",
+  "removedByHost": "Sei stato rimosso dal gioco dall'host.",
   "gameNotFound": "Gioco non trovato",
   "joining": "Unione in corso...",
   "error": "Errore",

--- a/tests/e2e/game-flow.spec.ts
+++ b/tests/e2e/game-flow.spec.ts
@@ -118,8 +118,9 @@ test('host removes player from lobby', async ({ browser }) => {
     // Host now sees only their own badge
     await expect(page1.locator('[data-testid^="player-badge-"]')).toHaveCount(1, { timeout: 5_000 });
 
-    // Player 2's next poll returns 403 → error message is shown
+    // Player 2's next poll returns 403 → "removed by host" error message is shown
     await expect(page2.getByTestId('error-message')).toBeVisible({ timeout: 5_000 });
+    await expect(page2.getByTestId('error-message')).not.toContainText('Fehler beim Beitreten');
   } finally {
     await ctx1.close();
     await ctx2.close();


### PR DESCRIPTION
## Problem

When a host removes a player, that player's next poll to `/api/getGameDetails` returns **403**. The frontend treated both `401` (missing secret) and `403` (secret no longer in game) identically and showed the generic **"Fehler beim Beitreten"** message — which implies a join error, not a removal.

## Fix

- Split the `401` / `403` handling in `src/app/game/[gameId]/page.tsx`
- Added a new i18n key `removedByHost` in all 5 locale files:
  - 🇩🇪 *"Du wurdest vom Host aus dem Spiel entfernt."*
  - 🇬🇧 *"You have been removed from the game by the host."*
  - 🇪🇸 *"El anfitrión te ha eliminado del juego."*
  - 🇫🇷 *"L'hôte vous a retiré du jeu."*
  - 🇮🇹 *"Sei stato rimosso dal gioco dall'host."*
- Tightened the existing E2E test to assert the removal message ≠ generic join error

## Test plan

- [x] All 52 unit/integration tests pass (`npm test`)
- [x] E2E test `host removes player from lobby` updated to assert correct message

🤖 Generated with [Claude Code](https://claude.com/claude-code)