### PR TITLE
Sync UI language from game data on every poll

### DIFF
--- a/src/app/game/[gameId]/page.tsx
+++ b/src/app/game/[gameId]/page.tsx
@@ -4,7 +4,7 @@
 import { useEffect, useState, useCallback, useRef } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { QRCodeSVG } from 'qrcode.react';
-import { useLanguage } from "@/shared/i18n/LanguageContext";
+import { useLanguage, type Locale } from "@/shared/i18n/LanguageContext";
 
 type PlayerDTO = {
   id: string;
@@ -26,6 +26,7 @@ type GameDTO = {
   gameId: string;
   joinCode?: string;
   status: "JOINING" | "STARTED" | "FINISHED";
+  language: Locale;
   players: PlayerDTO[];
   turns: TurnDTO[];
 };
@@ -33,7 +34,7 @@ type GameDTO = {
 export default function GameRoom() {
   const { gameId } = useParams<{ gameId: string }>();
   const router = useRouter();
-  const { t } = useLanguage();
+  const { t, setLanguage } = useLanguage();
   
   const [game, setGame] = useState<GameDTO | null>(null);
   const [loading, setLoading] = useState(true);
@@ -91,6 +92,7 @@ export default function GameRoom() {
         if (res.ok) {
            const data = await res.json();
            setGame(data);
+           setLanguage(data.language);
            setError("");
         } else {
            setError(t("error"));
@@ -106,7 +108,7 @@ export default function GameRoom() {
     const interval = setInterval(fetchGame, 2000); 
 
     return () => clearInterval(interval);
-  }, [gameId, router, t, getSecret]); // Added getSecret to dependencies
+  }, [gameId, router, t, getSecret, setLanguage]);
 
   const apiCall = async (endpoint: string) => {
     const secret = getSecret();

--- a/src/shared/i18n/LanguageContext.tsx
+++ b/src/shared/i18n/LanguageContext.tsx
@@ -1,7 +1,7 @@
 
 "use client";
 
-import React, { createContext, useContext, useState, ReactNode } from 'react';
+import React, { createContext, useContext, useState, useCallback, ReactNode } from 'react';
 import de from '../locales/de.json';
 import en from '../locales/en.json';
 import es from '../locales/es.json';
@@ -34,10 +34,10 @@ export const LanguageProvider = ({ children }: { children: ReactNode }) => {
     return storedLang && translations[storedLang] ? storedLang : 'de-DE';
   });
 
-  const handleSetLanguage = (lang: Locale) => {
+  const handleSetLanguage = useCallback((lang: Locale) => {
     setLanguage(lang);
     localStorage.setItem('impostor_language', lang);
-  };
+  }, []);
 
   const t = (key: keyof Translations) => {
     return translations[language][key] || key;


### PR DESCRIPTION
## Summary
- After each successful `getGameDetails` fetch, the client calls `setLanguage(data.language)` — all players now automatically switch to the language the host chose when creating the game
- `handleSetLanguage` in `LanguageContext` is now wrapped in `useCallback` so the setter is reference-stable and can safely be listed as a `useEffect` dependency

## Test plan
- [ ] Host creates game in French (`fr-FR`)
- [ ] Player joins with a different browser language (e.g. `de-DE`)
- [ ] Player's UI switches to French automatically within 2 seconds (next poll)
- [ ] All 52 Jest integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)