### PR TITLE
Add Playwright HTML report publishing to GitHub Pages

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -188,6 +188,30 @@ jobs:
           path: test-results/
           retention-days: 30
 
+      - name: Push Report to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        if: always()
+        with:
+          external_repository: mschmiedel/mschmiedel-reports
+          publish_branch: gh-pages
+          personal_token: ${{ secrets.REPORT_DEPLOY_TOKEN }}
+          publish_dir: ./playwright-report
+          destination_dir: ${{ github.event.repository.name }}/pr-${{ github.event.pull_request.number || github.run_number }}
+          keep_files: true
+          force_orphan: true
+
+      - name: Post Playwright Report Link to PR
+        uses: actions/github-script@v7
+        if: always() && github.event_name == 'pull_request'
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `## 🎭 Playwright Report\n\n[View full HTML report](https://mschmiedel.github.io/mschmiedel-reports/${{ github.event.repository.name }}/pr-${{ github.event.pull_request.number }}/index.html)`,
+            });
+
       - name: Stop containers
         if: always()
         env:

--- a/.github/workflows/cleanup-reports.yml
+++ b/.github/workflows/cleanup-reports.yml
@@ -1,0 +1,25 @@
+name: Cleanup Playwright Reports
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout reports repository
+        uses: actions/checkout@v4
+        with:
+          repository: mschmiedel/mschmiedel-reports
+          token: ${{ secrets.REPORT_DEPLOY_TOKEN }}
+          ref: gh-pages
+
+      - name: Remove PR report and push
+        run: |
+          rm -rf ${{ github.event.repository.name }}/pr-${{ github.event.pull_request.number }}
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "Cleanup report for ${{ github.event.repository.name }} PR-${{ github.event.pull_request.number }}" || echo "No changes to commit"
+          git push origin gh-pages

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,10 +4,9 @@ export default defineConfig({
   testDir: './tests/e2e',
   timeout: 120_000,
   expect: { timeout: 15_000 },
-  reporter: [
-    ['html', { open: 'never' }],
-    ['json', { outputFile: 'test-results/results.json' }],
-  ],
+  reporter: process.env.CI
+    ? [['github'], ['html'], ['json', { outputFile: 'test-results/results.json' }]]
+    : [['list'], ['html'], ['json', { outputFile: 'test-results/results.json' }]],
   use: {
     baseURL: 'http://localhost:3000',
     screenshot: 'on',


### PR DESCRIPTION
## Summary

- **Playwright config**: In CI the reporter is now `[github, html, json]` for native GHA annotations; locally `[list, html, json]` for readable console output. The JSON reporter is kept in both modes so the existing `daun/playwright-report-summary` step continues to work.
- **Push to external repo**: After every e2e run (pass _or_ fail) the `playwright-report/` directory is pushed to `mschmiedel/mschmiedel-reports` → branch `gh-pages` under `impostor-game/pr-<number>` (or `run-<number>` for non-PR runs) via `peaceiris/actions-gh-pages@v4`.
- **PR comment**: A comment with a direct link to the published report is posted on the pull request after each run.
- **Auto-cleanup**: New `cleanup-reports.yml` workflow fires on `pull_request: [closed]` and removes the report directory from the external repo, keeping the Pages site tidy.

## Prerequisites

- Secret `REPORT_DEPLOY_TOKEN` must be set in this repo (PAT with `repo` write access to `mschmiedel/mschmiedel-reports`).
- GitHub Pages must be enabled on `mschmiedel/mschmiedel-reports` serving from the `gh-pages` branch.

## Test plan

- [ ] Merge a PR → e2e job publishes report → PR comment appears with working link
- [ ] Close the PR → cleanup workflow runs → directory removed from `mschmiedel-reports`
- [ ] Push to `main` (non-PR) → report published under `impostor-game/pr-<run_number>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)