### PR TITLE
Add discreet Ad Banner via flexbox layout

### DIFF
--- a/src/app/components/AdBanner.tsx
+++ b/src/app/components/AdBanner.tsx
@@ -1,0 +1,7 @@
+export default function AdBanner() {
+  return (
+    <footer className="h-14 bg-gray-100 dark:bg-slate-950 text-gray-400 text-xs text-center border-t dark:border-slate-800 flex items-center justify-center">
+      Advertisement
+    </footer>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
 import { LanguageProvider } from "@/shared/i18n/LanguageContext";
+import AdBanner from "@/app/components/AdBanner";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -17,9 +18,12 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={inter.className}>
+      <body className={`${inter.className} min-h-[100dvh] flex flex-col`}>
         <LanguageProvider>
-          {children}
+          <main className="flex-grow flex flex-col">
+            {children}
+          </main>
+          <AdBanner />
         </LanguageProvider>
       </body>
     </html>


### PR DESCRIPTION
Closes #26

## Summary

- New `src/app/components/AdBanner.tsx`: slim `h-14` footer, muted Tailwind classes for light/dark mode (`bg-gray-100 dark:bg-slate-950 text-gray-400`), placeholder text "Advertisement". No `fixed`/`absolute` positioning.
- `src/app/layout.tsx`: `<body>` gets `min-h-[100dvh] flex flex-col` (`dvh` for mobile-Safari viewport fix); `{children}` wrapped in `<main className="flex-grow flex flex-col">`; `<AdBanner />` placed directly after `</main>` so flexbox naturally pushes it to the bottom of every page.

## Test plan

- [ ] `npm run build` — no TypeScript errors
- [ ] Open app locally → banner visible at bottom of every page
- [ ] Resize to mobile viewport → banner stays at bottom, does not overlap game buttons
- [ ] Dark mode → banner uses `dark:bg-slate-950` styling
- [ ] E2E tests pass — banner is below all interactive content, no click interception

🤖 Generated with [Claude Code](https://claude.com/claude-code)